### PR TITLE
Capitalize `h` in the `GitHub` word in the footer

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -94,7 +94,7 @@
     </main>
     <footer class="page-grid-footer">
         <nav>
-            <a href="https://github.com/darkreader/darkreader">Github</a>
+            <a href="https://github.com/darkreader/darkreader">GitHub</a>
             <a href="https://twitter.com/darkreaderapp">Twitter</a>
             <a href="mailto:darkreaderapp@gmail.com">Contact</a>
         </nav>


### PR DESCRIPTION
Things added/changed:

- Capitalize `h` in the `GitHub` word in the footer.
  - Also changed the link to go to the organization's profile, not the Dark Reader repository itself.
